### PR TITLE
Fix character encoding

### DIFF
--- a/exercises/solutions/ex5_city_rent_comparison.rb
+++ b/exercises/solutions/ex5_city_rent_comparison.rb
@@ -8,7 +8,7 @@ require 'csv'
 highest_rent = 0
 highest_rent_city_name = ""
 
-CSV.foreach('rent-data.csv', :encoding => 'ISO-8859-1') do |row|
+CSV.foreach('rent-data.csv') do |row|
   # Loop through each of the rows
     # Compare cities using or/and statements to narrow down the data
     if ((row.include? "Edmonton, Alberta" or row.include? "Toronto, Ontario") and row.include? "2008")


### PR DESCRIPTION
It was not obvious that we had to open the `rent-data.csv` in Latin-1 encoding, so I re-encoded it in UTF-8, which should be the default on most systems. This should make future workshops go smoother :D