### PR TITLE
Replace and and or operators

### DIFF
--- a/exercises/solutions/ex3_smarter_weather.rb
+++ b/exercises/solutions/ex3_smarter_weather.rb
@@ -7,7 +7,7 @@ weather = gets.chomp.to_i
 if weather >= 25
     print "Go to the beach!\n" # The '\n' adds a new line so it prints nicely.
 # the weather is less than 25 degrees AND greater than 15 degrees
-elsif weather < 25 and weather > 15
+elsif weather < 25 && weather > 15
     # Still warm enough for ice cream!
     print "I'm getting ice cream!\n"
 else

--- a/exercises/solutions/ex5_city_rent_comparison.rb
+++ b/exercises/solutions/ex5_city_rent_comparison.rb
@@ -11,7 +11,7 @@ highest_rent_city_name = ""
 # Loop through each of the rows
 for row in data
     # If this row is for a city of interest
-    if ((row.include? "Edmonton, Alberta" or row.include? "Toronto, Ontario") and row.include? "2008")
+    if ((row.include?("Edmonton, Alberta") || row.include?( "Toronto, Ontario")) && row.include?("2008"))
         # Print the row
         puts row.to_s + "\n"
         # If the rent is the highest so far

--- a/exercises/solutions/ex5_city_rent_comparison.rb
+++ b/exercises/solutions/ex5_city_rent_comparison.rb
@@ -11,7 +11,7 @@ highest_rent_city_name = ""
 # Loop through each of the rows
 for row in data
     # If this row is for a city of interest
-    if ((row.include?("Edmonton, Alberta") || row.include?( "Toronto, Ontario")) && row.include?("2008"))
+    if ((row.include?("Edmonton, Alberta") || row.include?("Toronto, Ontario")) && row.include?("2008"))
         # Print the row
         puts row.to_s + "\n"
         # If the rent is the highest so far

--- a/exercises/solutions/final_exercise.rb
+++ b/exercises/solutions/final_exercise.rb
@@ -15,6 +15,12 @@ April 9 2019
 Jakob Leben - jakob.leben@gmail.com
 
 Adapted to use only the Ruby features presented on the slides.
+
+---
+April 27 2019
+Susan Wright - wright1@ualberta.ca
+
+Altered to use the '&&' and '||' syntax instead of 'and' and 'or'
 =end
 
 require 'csv'
@@ -38,7 +44,7 @@ def average_rent(data, selected_type, selected_province, decade)
         type = row[4]
         rent = row[7].to_i
 
-        if type == selected_type and location.include? selected_province and year >= decade and year < decade + 10
+        if type == selected_type && location.include?(selected_province) && year >= decade && year < decade + 10
             count += 1
             rent_sum += rent
         end

--- a/slides.html
+++ b/slides.html
@@ -1034,23 +1034,23 @@
 
     <section class="slide" data-markdown>
       <script type="text/template">
-        # And / Or
+        # && / ||
 
         Sometimes, you can&rsquo;t neatly capture your conditions with one expression. You need to combine multiple expressions to determine what to do next.
 
-        `and`: both things must be true  
-        `or`: either one, or both things must be true
+        `&&`: both things must be true  
+        `||`: either one, or both things must be true
 
         ```ruby
         weather = "cold"
         snowing = true
 
-        irb> if weather == "cold" and snowing == true
+        irb> if weather == "cold" && snowing == true
         ...      print "wear a winter jacket"
         ...  end
 
         wear a winter jacket
-        irb> if weather == "raining" or snowing == true
+        irb> if weather == "raining" || snowing == true
         ...      print "bring a change of socks"
         ...  end
         bring a change of socks
@@ -1060,27 +1060,27 @@
 
     <section class="slide" data-markdown>
       <script type="text/template">
-        # Examples with and/or
+        # Examples with &&/||
 
         Take note! Whereas in math notation you can write `0 < x < 6`, in ruby you need to split these into separate comparisons
 
         ```ruby
         irb> x = 5
-        irb> if x > 0 and x < 6
+        irb> if x > 0 && x < 6
         ...      print "x is between 0 and 6."
         ...  end
         x is between 0 and 6.
         ```
 
         ```ruby
-        irb> if x.class == Float or x.class == Fixnum
+        irb> if x.class == Float || x.class == Fixnum
         ...      print "x is a numeric value"
         ...  end
         x is a numeric value
         ```
 
         ```ruby
-        irb> if x > 10 and x < 0
+        irb> if x > 10 && x < 0
         ...      print "x could never be greater than 10 AND less than 0"
         ...  end
         # Nothing prints here
@@ -1097,7 +1097,7 @@
 
         Instead of telling your program if it&rsquo;s cold, you can input the temperature and let it decide what to do.
 
-        Open **smarter_weather.rb** and follow the instructions. Use math comparison operators as well as `and`/`or` to complete the exercise.
+        Open **smarter_weather.rb** and follow the instructions. Use math comparison operators as well as `&&`/`||` to complete the exercise.
 
         ```ruby
         # if the weather is greater than or equal to 25 degrees


### PR DESCRIPTION
`and` and `or` are very dangerous operators. An excellent explanation on the dangers was given in [this Stack Overflow answer.](https://stackoverflow.com/a/2376435/1282499).
To summarize, `and` and `or` can lead to dangerous bugs, and assigning the wrong value to variables.
While this is an intro course, I believe it's a terrible situation to introduce learners to bad coding practice, regardless of how much easier it appears on the surface. Anyone leaving this course and intending to continue to learn Ruby will need to unlearn bad habits.
This PR replaces the usage of `and` and `or` with the `&&` and `||` operators that are very much preferred in the Ruby community.