### PR TITLE
Remove functions

### DIFF
--- a/exercises/final_exercise.rb
+++ b/exercises/final_exercise.rb
@@ -5,14 +5,64 @@ require 'csv'
 
 # Pick a province and a rental unit type (take a look at the CSV file for examples)
 #     - selected_type: Type of rental unit of interest (for example "One bedroom units")
+
 #     - selected_province: Province of interest (for example "Alberta")
+
 
 # Calculate the average rent for the desired province and rental unit type in the 80s.
 
+# Keep a count of the number of rental units.
+
+# Keep a sum of all of the rents
+
+
+# For each row in the CSV file...
+
+    # Get the year from the row and convert it to an integer
+
+    # Get the location from the row
+
+    # Get the rental unit type from the row
+
+    # Get the price of rent from the row and convert it to an number
+
+
+    # Add the rent to the rent sum ONLY when the type in the row is the selected
+    # type AND when the location contains the province AND when the year is
+    # between 1980 and 1989, inclusive.
+
+# Average rent is sum of all the rents divided by how many units we've
+# counted. Make sure to avoid dividing by zero: then the average is 0!
+
 # Print this value.
 
-# Do the same for the 90s. i.e.,
+
+
+# Do the same for the 90s. To reiterate:
 # Calculate the average rent for the desired province and rental unit type in the 90s.
+
+# Keep a count of the number of rental units.
+
+# Keep a sum of all of the rents
+
+
+# For each row in the CSV file...
+
+    # Get the year from the row and convert it to an integer
+
+    # Get the location from the row
+
+    # Get the rental unit type from the row
+
+    # Get the price of rent from the row and convert it to an number
+
+
+    # Add the rent to the rent sum ONLY when the type in the row is the selected
+    # type AND when the location contains the province AND when the year is
+    # between 1990 and 1999, inclusive.
+
+# Average rent is sum of all the rents divided by how many units we've
+# counted. Make sure to avoid dividing by zero: then the average is 0!
 
 # Print this value.
 

--- a/exercises/final_exercise.rb
+++ b/exercises/final_exercise.rb
@@ -1,25 +1,19 @@
 require 'csv'
 
-# Function 'average_rent':
-#     Find average rent for a specific type of rental units
-#     in a specific province and in a specific decade.
-# Arguments:
-#     - data: CSV data returned by CSV.read
-#     - selected_type: Type of rental unit of interest (for example "One bedroom units")
-#     - selected_province: Province of interest (for example "Alberta")
-#     - decade: First year in the decade of interest (for example 1980)
-
-def average_rent(data, selected_type, selected_province, decade)
-    # Complete
-end
 
 # Read data from the CSV file 'rent-data.csv'
 
 # Pick a province and a rental unit type (take a look at the CSV file for examples)
+#     - selected_type: Type of rental unit of interest (for example "One bedroom units")
+#     - selected_province: Province of interest (for example "Alberta")
 
-# Call the function 'average_rent' to get the average rent for the desired province and rental unit type in the 80s.
+# Calculate the average rent for the desired province and rental unit type in the 80s.
+
 # Print this value.
 
-# Do the same for the 90s.
+# Do the same for the 90s. i.e.,
+# Calculate the average rent for the desired province and rental unit type in the 90s.
+
+# Print this value.
 
 # Calculate and print the difference between the average rent in the 90s and in the 80s.

--- a/exercises/solutions/final_exercise.rb
+++ b/exercises/solutions/final_exercise.rb
@@ -15,52 +15,81 @@ April 9 2019
 Jakob Leben - jakob.leben@gmail.com
 
 Adapted to use only the Ruby features presented on the slides.
+
+---
+April 28 2019
+Eddie Antonio Santos - Eddie.Santos@nrc-cnrc.gc.ca
+
+Further adapted to no longer use functions.
 =end
 
 require 'csv'
 
-# Function 'average_rent':
-#     Find average rent for a specific type of rental units
-#     in a specific province and in a specific decade.
-# Arguments:
-#     - data: CSV data returned by CSV.read
+# Read data from the CSV file 'rent-data.csv'
+data = CSV.read('exercises/rent-data.csv')
+
+# Pick a province and a rental unit type (take a look at the CSV file for examples)
 #     - selected_type: Type of rental unit of interest (for example "One bedroom units")
+selected_type = "One bedroom units"
 #     - selected_province: Province of interest (for example "Alberta")
-#     - decade: First year in the decade of interest (for example 1980)
+selected_province = "Alberta"
 
-def average_rent(data, selected_type, selected_province, decade)
-    count = 0
-    rent_sum = 0
+# Calculate the average rent for the desired province and rental unit type in the 80s.
+count = 0
+rent_sum = 0
 
-    for row in data
-        year = row[0].to_i
-        location = row[1]
-        type = row[4]
-        rent = row[7].to_i
+for row in data
+    year = row[0].to_i
+    location = row[1]
+    type = row[4]
+    rent = row[7].to_i
 
-        if type == selected_type and location.include? selected_province and year >= decade and year < decade + 10
-            count += 1
-            rent_sum += rent
-        end
-    end
-
-    if count == 0
-        return 0
-    else
-        return rent_sum / count
+    if type == selected_type && location.include?(selected_province) && year >= 1980 && year <= 1989
+        count += 1
+        rent_sum += rent
     end
 end
 
-type = "One bedroom units"
-province = "Alberta"
+if count == 0
+    rent_80s = 0
+else
+    rent_80s = rent_sum / count
+end
 
-data = CSV.read('exercises/rent-data.csv')
-rent_80s = average_rent(data, type, province, 1980)
-rent_90s = average_rent(data, type, province, 1990)
+# Print this value.
+puts "Average rent for " + selected_type + " in " + selected_province + " in the 80s was $" + rent_80s.to_s
 
-puts "Average rent for " + type + " in " + province + " in the 80s was $" + rent_80s.to_s
-puts "Average rent for " + type + " in " + province + " in the 90s was $" + rent_90s.to_s
+
+# Do the same for the 90s. To reiterate:
+# Calculate the average rent for the desired province and rental unit type in the 90s.
+count = 0
+rent_sum = 0
+
+for row in data
+    year = row[0].to_i
+    location = row[1]
+    type = row[4]
+    rent = row[7].to_i
+
+    if type == selected_type && location.include?(selected_province) && year >= 1990 && year <= 1999
+        count += 1
+        rent_sum += rent
+    end
+end
+
+if count == 0
+    rent_90s = 0
+else
+    rent_90s = rent_sum / count
+end
+
+# Print this value.
+puts "Average rent for " + selected_type + " in " + selected_province + " in the 90s was $" + rent_90s.to_s
+
+
+# Calculate and print the difference between the average rent in the 90s and in the 80s.
 puts "Difference is: $" + (rent_90s - rent_80s).to_s
+
 
 =begin
 # Selection sort (very slow on large lists)
@@ -73,7 +102,7 @@ size_of_list.times do |item|
   (item + 1).upto(size_of_list) do |j|
     index_min = j if a[j] < a[index_min]
   end
-    list[i], list[index_min] = list[index_min], list[i] if index_min != item
+  list[i], list[index_min] = list[index_min], list[i] if index_min != item
 end
 
 =end

--- a/exercises/solutions/final_exercise.rb
+++ b/exercises/solutions/final_exercise.rb
@@ -26,7 +26,7 @@ Further adapted to no longer use functions.
 require 'csv'
 
 # Read data from the CSV file 'rent-data.csv'
-data = CSV.read('exercises/rent-data.csv')
+data = CSV.read("exercises/rent-data.csv")
 
 # Pick a province and a rental unit type (take a look at the CSV file for examples)
 #     - selected_type: Type of rental unit of interest (for example "One bedroom units")
@@ -35,21 +35,34 @@ selected_type = "One bedroom units"
 selected_province = "Alberta"
 
 # Calculate the average rent for the desired province and rental unit type in the 80s.
+
+# Keep a count of the number of rental units.
 count = 0
+# Keep a sum of all of the rents
 rent_sum = 0
 
+# For each row in the CSV file...
 for row in data
+    # Get the year from the row and convert it to an integer
     year = row[0].to_i
+    # Get the location from the row
     location = row[1]
+    # Get the rental unit type from the row
     type = row[4]
+    # Get the price of rent from the row and convert it to an number
     rent = row[7].to_i
 
+    # Add the rent to the rent sum ONLY when the type in the row is selected
+    # type AND when the location contains the province AND when the year is
+    # between 1980 and 1989, inclusive.
     if type == selected_type && location.include?(selected_province) && year >= 1980 && year <= 1989
         count += 1
         rent_sum += rent
     end
 end
 
+# Average rent is sum of all the rents divided by how many units we've
+# counted. Make sure to avoid dividing by zero: then the average is 0!
 if count == 0
     rent_80s = 0
 else
@@ -62,21 +75,34 @@ puts "Average rent for " + selected_type + " in " + selected_province + " in the
 
 # Do the same for the 90s. To reiterate:
 # Calculate the average rent for the desired province and rental unit type in the 90s.
+
+# Keep a count of the number of rental units.
 count = 0
+# Keep a sum of all of the rents
 rent_sum = 0
 
+# For each row in the CSV file...
 for row in data
+    # Get the year from the row and convert it to an integer
     year = row[0].to_i
+    # Get the location from the row
     location = row[1]
+    # Get the rental unit type from the row
     type = row[4]
+    # Get the price of rent from the row and convert it to an number
     rent = row[7].to_i
 
+    # Add the rent to the rent sum ONLY when the type in the row is selected
+    # type AND when the location contains the province AND when the year is
+    # between 1990 and 1999, inclusive.
     if type == selected_type && location.include?(selected_province) && year >= 1990 && year <= 1999
         count += 1
         rent_sum += rent
     end
 end
 
+# Average rent is sum of all the rents divided by how many units we've
+# counted. Make sure to avoid dividing by zero: then the average is 0!
 if count == 0
     rent_90s = 0
 else

--- a/exercises/solutions/final_exercise.rb
+++ b/exercises/solutions/final_exercise.rb
@@ -52,7 +52,7 @@ for row in data
     # Get the price of rent from the row and convert it to an number
     rent = row[7].to_i
 
-    # Add the rent to the rent sum ONLY when the type in the row is selected
+    # Add the rent to the rent sum ONLY when the type in the row is the selected
     # type AND when the location contains the province AND when the year is
     # between 1980 and 1989, inclusive.
     if type == selected_type && location.include?(selected_province) && year >= 1980 && year <= 1989
@@ -92,7 +92,7 @@ for row in data
     # Get the price of rent from the row and convert it to an number
     rent = row[7].to_i
 
-    # Add the rent to the rent sum ONLY when the type in the row is selected
+    # Add the rent to the rent sum ONLY when the type in the row is the selected
     # type AND when the location contains the province AND when the year is
     # between 1990 and 1999, inclusive.
     if type == selected_type && location.include?(selected_province) && year >= 1990 && year <= 1999

--- a/slides.html
+++ b/slides.html
@@ -1487,7 +1487,7 @@
 
         Open **final_exercise.rb** and complete the exercise:
 
-        * Complete a function that computes the **average rent** in a chosen **decade** for a chosen province and rental unit type.
+        * Write code that computes the **average rent** in a chosen **decade** for a chosen province and rental unit type.
         * Find the **difference** between the average rent in the **1980s** and in the **1990s**.
         *  **Bonus Exercise**: Use **selection sort** to sort a list of provinces from the highest to the lowest average rent.
 

--- a/slides.html
+++ b/slides.html
@@ -338,63 +338,6 @@
       </script>
     </section>
 
-    <section class="slide no-bullet-list" data-markdown>
-      <script type="text/template">
-        #Functions
-
-        * Functions are bundles of instructions that can be re-used
-          * Defined by wrapping the instructions between `def` and `end`
-          * Directly after `def` is the name of the function
-        * Function can take **arguments** and **return** values
-          * After the function name, **arguments** are defined in parentheses, `()`
-        * Functions always `return` 1 thing or a set of things
-
-        ```ruby
-        def functionName(arg1, arg2)
-          set of instructions
-          return answer
-        end
-        ```
-      </script>
-    </section>
-
-    <section class="slide" data-markdown>
-      <script type="text/template">
-        #Define the function
-
-        This doesn't actually run the code.  We're just telling the computer what to expect.
-
-        In the below example, the `add` function takes `a` and `b` as arguments and will **return** the result.
-
-        ```ruby
-        irb> def add(a, b)
-        ...      return a + b
-        ...  end
-        ...
-        ```
-      </script>
-    </section>
-
-    <section class="slide" data-markdown>
-      <script type="text/template">
-        #Call the function
-
-        After *defining* the function, *call* it by typing the name of the function, `add()` and substituting values where the arguments were defined `(a,b)`.
-
-        ```ruby
-        irb> add(1, 2)
-        => 3
-        ```
-
-        The benefit is now we can sub in any 2 numbers without having to rewrite the code.
-
-        ```ruby
-        irb> add(3, 4)
-        => 7
-        ```
-        We won't create our own functions in today's exercises, but we'll use those provided by ruby and its libraries.
-      </script>
-    </section>
     <section class="slide" data-markdown>
       <script type="text/template">
         #Outputting values: `puts`

--- a/slides.html
+++ b/slides.html
@@ -396,7 +396,7 @@
       <script type="text/template">
         #What's nil? It's nothing, don't worry.
 
-        Remember how **Functions** always return 1 thing?
+        Every **function** returns a value.
 
         Well, `print` and `puts` are functions.  However, since they only print to the screen they *technically* don't return anything.
 


### PR DESCRIPTION
This pull request removes the brief introduction to functions in the slides. In the current version of the slides, functions are introduced before variables, before if/else, and before loops 🤔. Functions themselves present tricky syntax that learners frequently stumble upon. Even worse, aside from the final exercise casually asking the learners to define a function to solve it, defining functions is **never** mentioned or practiced in the rest of the slide deck!

As such, myself and a few other mentors/instructors have concurred that functions should not be introduced in the slide deck at all, in order to reduce cognitive burden, lessen the amount of syntax to remember, and as to avoid explaining concepts like scope, argument passing, return values, etc., — especially when they are not at all required to solve any of the exercises in this workshop.

Don't get me wrong — functions are my favourite thing in computer science! — but it's better to introduce them a bit later in a learner's journey in learning how to code, rather than early on a Saturday morning! 😄 