### PR TITLE
Change all instances of `Fixnum` to `Integer`. Fixes #10.

### DIFF
--- a/slides.html
+++ b/slides.html
@@ -424,7 +424,7 @@
         But what if we try to join a string and a number?
 
         ```ruby
-        irb> print 2 + "2"
+        irb> puts 2 + "2"
         TypeError: String cannot be coerced into Integer
 
         ```
@@ -438,7 +438,7 @@
         Ruby needs to know the **type** of data the value is to figure out how to work with it.  Let&rsquo;s look at that error again.
 
         ```ruby
-        irb> print 2 + "2"
+        irb> puts 2 + "2"
         TypeError: String cannot be coerced into Integer
         ```
 
@@ -517,7 +517,7 @@
         Ruby can also be used to convert numbers to strings.
 
         ```
-        irb> print 3 + " items in my bento!"
+        irb> puts 3 + " items in my bento!"
         TypeError: String cant be coerced into Integer
 
         ```
@@ -1026,7 +1026,7 @@
 
         ```ruby
         irb> if x.is_a?(Float) || x.is_a?(Integer)
-        ...      print "x is a numeric value"
+        ...      puts "x is a numeric value"
         ...  end
         x is a numeric value
         ```

--- a/slides.html
+++ b/slides.html
@@ -289,7 +289,7 @@
 
         We just used the *integer* number **class** but there are many more.
 
-        * Integer/Fixnum (whole numbers)
+        * Integer (whole numbers)
         * Float (numbers containing decimals)
         * String (words, sentences, literal text) - requires quotes
         * Boolean (`true`, `false`)
@@ -302,11 +302,15 @@
         => String
 
         irb> 42.class
-        => Fixnum
+        => Integer
 
         irb> 3.14159.class
         => Float
         ```
+
+        Heads up! Older versions of Ruby call it `Fixnum` instead of
+        `Integer`. For the purposes of this workshop, whenever you see
+        `Integer` in your code, you can safely replace it with `Fixnum`.
       </script>
     </section>
     <section class="slide" data-markdown>
@@ -420,8 +424,8 @@
         But what if we try to join a string and a number?
 
         ```ruby
-        irb> puts 2 + "2"
-        TypeError: String cannot be coerced into Fixnum
+        irb> print 2 + "2"
+        TypeError: String cannot be coerced into Integer
 
         ```
       </script>
@@ -434,8 +438,8 @@
         Ruby needs to know the **type** of data the value is to figure out how to work with it.  Let&rsquo;s look at that error again.
 
         ```ruby
-        irb> puts 2 + "2"
-        TypeError: String cannot be coerced into Fixnum
+        irb> print 2 + "2"
+        TypeError: String cannot be coerced into Integer
         ```
 
         * The first `2`, inside of `puts 2 + "2"` is an integer.
@@ -513,8 +517,8 @@
         Ruby can also be used to convert numbers to strings.
 
         ```
-        irb> puts 3 + " items in my bento!"
-        TypeError: String cant be coerced into Fixnum
+        irb> print 3 + " items in my bento!"
+        TypeError: String cant be coerced into Integer
 
         ```
         Use the `.to_s` method to convert a number to a string.
@@ -1021,8 +1025,8 @@
         ```
 
         ```ruby
-        irb> if x.class == Float || x.class == Fixnum
-        ...      puts "x is a numeric value"
+        irb> if x.is_a?(Float) || x.is_a?(Integer)
+        ...      print "x is a numeric value"
         ...  end
         x is a numeric value
         ```

--- a/slides.html
+++ b/slides.html
@@ -309,8 +309,7 @@
         ```
 
         Heads up! Older versions of Ruby call it `Fixnum` instead of
-        `Integer`. For the purposes of this workshop, whenever you see
-        `Integer` in your code, you can safely replace it with `Fixnum`.
+        `Integer`.
       </script>
     </section>
     <section class="slide" data-markdown>


### PR DESCRIPTION
**NOTE**: this is a fixed version of #20! This resolves the conflicts introduced by that PR.

Anywhere it said Fixnum, I changed to Integer. This works for all versions of Ruby 2.x, as far as I'm aware. However `42.class` may return Fixnum in older versions.

I also added a quick note for people using old versions of Ruby (mostly macOS users).

Closes #10 
Closes #20